### PR TITLE
Allow seo/social meta tag attributes

### DIFF
--- a/Sources/Elementary/HtmlAttributes.swift
+++ b/Sources/Elementary/HtmlAttributes.swift
@@ -42,8 +42,16 @@ public extension HTMLAttribute where Tag: HTMLTrait.Attributes.Global {
 
 // meta tag attributes
 public extension HTMLAttribute where Tag == HTMLTag.meta {
-    struct Name: Sendable {
+    struct Name: Sendable, ExpressibleByStringLiteral {
         var value: String
+
+        init(value: String) {
+            self.value = value
+        }
+
+        public init(stringLiteral value: String) {
+            self.value = value
+        }
 
         public static let author = Name(value: "author")
         public static let description = Name(value: "description")
@@ -57,6 +65,10 @@ public extension HTMLAttribute where Tag == HTMLTag.meta {
 
     static func content(_ value: String) -> Self {
         HTMLAttribute(name: "content", value: value)
+    }
+
+    static func property(_ value: String) -> Self {
+        HTMLAttribute(name: "property", value: value)
     }
 }
 


### PR DESCRIPTION
This PR allows a meta tag to use both custom and predefined name attributes. Also adds the property attribute to meta tags.
Both additions allow to set SEO and social media preview related contents in meta tags.