### PR TITLE
Initialize HTML elements with array of attributes

### DIFF
--- a/Sources/Elementary/Core/Html+Attributes.swift
+++ b/Sources/Elementary/Core/Html+Attributes.swift
@@ -79,6 +79,15 @@ public extension HTMLElement {
         self.attributes = .init(attributes)
         self.content = content()
     }
+
+    /// Creates a new HTML element with the specified attributes and content.
+    /// - Parameters:
+    ///  - attributes: The attributes to apply to the element as an array.
+    ///  - content: The content of the element.
+    init(_ attributes: [HTMLAttribute<Tag>], @HTMLBuilder content: () -> Content) {
+        self.attributes = .init(attributes)
+        self.content = content()
+    }
 }
 
 public extension HTMLVoidElement {
@@ -115,6 +124,15 @@ public extension HTML where Tag: HTMLTrait.Attributes.Global {
     ///   - condition: If set to false, the attributes will not be added.
     /// - Returns: A new element with the specified attributes added.
     func attributes(_ attributes: HTMLAttribute<Tag>..., when condition: Bool = true) -> _AttributedElement<Self> {
+        _AttributedElement(content: self, attributes: .init(condition ? attributes : []))
+    }
+
+    /// Adds the specified attributes to the element.
+    /// - Parameters:
+    ///   - attributes: The attributes to add to the element as an array.
+    ///   - condition: If set to false, the attributes will not be added.
+    /// - Returns: A new element with the specified attributes added.
+    func attributes(_ attributes: [HTMLAttribute<Tag>], when condition: Bool = true) -> _AttributedElement<Self> {
         _AttributedElement(content: self, attributes: .init(condition ? attributes : []))
     }
 }

--- a/Sources/Elementary/Core/Html+Attributes.swift
+++ b/Sources/Elementary/Core/Html+Attributes.swift
@@ -84,7 +84,7 @@ public extension HTMLElement {
     /// - Parameters:
     ///  - attributes: The attributes to apply to the element as an array.
     ///  - content: The content of the element.
-    init(_ attributes: [HTMLAttribute<Tag>], @HTMLBuilder content: () -> Content) {
+    init(attributes: [HTMLAttribute<Tag>], @HTMLBuilder content: () -> Content) {
         self.attributes = .init(attributes)
         self.content = content()
     }
@@ -100,6 +100,12 @@ public extension HTMLVoidElement {
     /// Creates a new HTML void element with the specified attributes.
     /// - Parameter attributes: The attributes to apply to the element.
     init(_ attributes: HTMLAttribute<Tag>...) {
+        self.attributes = .init(attributes)
+    }
+
+    /// Creates a new HTML void element with the specified attributes.
+    /// - Parameter attributes: The attributes to apply to the element as an array.
+    init(attributes: [HTMLAttribute<Tag>]) {
         self.attributes = .init(attributes)
     }
 }
@@ -132,7 +138,7 @@ public extension HTML where Tag: HTMLTrait.Attributes.Global {
     ///   - attributes: The attributes to add to the element as an array.
     ///   - condition: If set to false, the attributes will not be added.
     /// - Returns: A new element with the specified attributes added.
-    func attributes(_ attributes: [HTMLAttribute<Tag>], when condition: Bool = true) -> _AttributedElement<Self> {
+    func attributes(contentsOf attributes: [HTMLAttribute<Tag>], when condition: Bool = true) -> _AttributedElement<Self> {
         _AttributedElement(content: self, attributes: .init(condition ? attributes : []))
     }
 }

--- a/Tests/ElementaryTests/AttributeRenderingTests.swift
+++ b/Tests/ElementaryTests/AttributeRenderingTests.swift
@@ -102,4 +102,25 @@ final class AttributeRenderingTests: XCTestCase {
             #"<input type="text" required>"#
         )
     }
+
+    func testRendersAttributesArray() async throws {
+        try await HTMLAssertEqual(
+            p(attributes: [.id("foo"), .class("foo"), .hidden]) {},
+            #"<p id="foo" class="foo" hidden></p>"#
+        )
+    }
+
+    func testRendersAttributesArrayOnVoidElement() async throws {
+        try await HTMLAssertEqual(
+            input(attributes: [.type(.text), .required]),
+            #"<input type="text" required>"#
+        )
+    }
+
+    func testRendersAppliedConditionalAttributesArray() async throws {
+        try await HTMLAssertEqual(
+            img(.id("1")).attributes(contentsOf: [.class("2"), .id("no")], when: false).attributes(contentsOf: [.style("2")], when: true),
+            #"<img id="1" style="2">"#
+        )
+    }
 }


### PR DESCRIPTION
This allows to create custom HTML components and forward attributes from those to the underlying tag.

Example:
```swift
struct Title<Title: HTML>: HTML {
    var attributes: [HTMLAttribute<HTMLTag.h2>]
    var title: () -> Title

    init(attributes: HTMLAttribute<HTMLTag.h2>..., @HTMLBuilder title: @escaping () -> Title) {
        self.attributes = attributes + [.class("mt-14 text-base/7 font-semibold text-zinc-950 sm:text-sm/6 dark:text-white")]
        self.title = title
    }

    var content: some HTML {
        h2(attributes) {
            title()
        }
    }
}
```

Let me know if I should add tests for this.