### PR TITLE
Add ability to specify the `lang` attribute for a `HTMLDocument`

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@
 ```swift
 struct MainPage: HTMLDocument {
     var title = "Elementary"
-    var lang = "en"
 
     var head: some HTML {
         meta(.name(.description), .content("Typesafe HTML in modern Swift"))

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@
 
 ```swift
 struct MainPage: HTMLDocument {
-    var title: String = "Elementary"
+    var title = "Elementary"
+    var lang = "en"
 
     var head: some HTML {
         meta(.name(.description), .content("Typesafe HTML in modern Swift"))

--- a/Sources/Elementary/HtmlDocument.swift
+++ b/Sources/Elementary/HtmlDocument.swift
@@ -24,7 +24,7 @@ public protocol HTMLDocument: HTML {
     associatedtype HTMLBody: HTML
 
     var title: String { get }
-    var lang: String { get }
+    var lang: String { get } // Note: Not an optional to prevent accidental property overloading with type `String` in implementations
     @HTMLBuilder var head: HTMLHead { get }
     @HTMLBuilder var body: HTMLBody { get }
 }
@@ -39,10 +39,15 @@ public extension HTMLDocument {
             }
             Elementary.body { self.body }
         }
-        .attributes(.lang(lang), when: lang != "")
+        .attributes(.lang(lang), when: lang != .undefined)
     }
 }
 
 public extension HTMLDocument {
-    var lang: String { "" }
+    typealias Language = String
+    var lang: Language { .undefined }
+}
+
+extension HTMLDocument.Language {
+    static let undefined = HTMLDocument.Language()
 }

--- a/Sources/Elementary/HtmlDocument.swift
+++ b/Sources/Elementary/HtmlDocument.swift
@@ -1,12 +1,13 @@
 /// A type that represents a full HTML document.
 ///
 /// Provides a simple structure to model top-level HTML types.
-/// A default ``HTML/content`` implementation takes your ``title``, ``head`` and ``body``
-/// properties and renders them into a full HTML document.
+/// A default ``HTML/content`` implementation takes your ``title``, ``head``,  ``body`` and
+///  (optional) ``lang`` properties and renders them into a full HTML document.
 ///
 /// ```swift
 /// struct MyPage: HTMLDocument {
 ///   var title = "Hello, World!"
+///   var lang = "en"
 ///
 ///   var head: some HTML {
 ///     meta(.name(.viewport), .content("width=device-width, initial-scale=1.0"))
@@ -23,6 +24,7 @@ public protocol HTMLDocument: HTML {
     associatedtype HTMLBody: HTML
 
     var title: String { get }
+    var lang: String { get }
     @HTMLBuilder var head: HTMLHead { get }
     @HTMLBuilder var body: HTMLBody { get }
 }
@@ -37,5 +39,10 @@ public extension HTMLDocument {
             }
             Elementary.body { self.body }
         }
+        .attributes(.lang(lang), when: lang != "")
     }
+}
+
+public extension HTMLDocument {
+    var lang: String { "" }
 }

--- a/Sources/Elementary/HtmlDocument.swift
+++ b/Sources/Elementary/HtmlDocument.swift
@@ -1,7 +1,7 @@
 /// A type that represents a full HTML document.
 ///
 /// Provides a simple structure to model top-level HTML types.
-/// A default ``HTML/content`` implementation takes your ``title``, ``head``,  ``body`` and
+/// A default ``HTML/content`` implementation takes your ``title``, ``head``, ``body``, and
 ///  (optional) ``lang`` properties and renders them into a full HTML document.
 ///
 /// ```swift
@@ -24,7 +24,7 @@ public protocol HTMLDocument: HTML {
     associatedtype HTMLBody: HTML
 
     var title: String { get }
-    var lang: String { get } // Note: Not an optional to prevent accidental property overloading with type `String` in implementations
+    var lang: String { get }
     @HTMLBuilder var head: HTMLHead { get }
     @HTMLBuilder var body: HTMLBody { get }
 }
@@ -39,15 +39,16 @@ public extension HTMLDocument {
             }
             Elementary.body { self.body }
         }
-        .attributes(.lang(lang), when: lang != .undefined)
+        .attributes(.lang(lang), when: lang != defaultUndefinedLanguage)
     }
 }
 
-public extension HTMLDocument {
-    typealias Language = String
-    var lang: Language { .undefined }
-}
+// NOTE: The default implementation uses an empty string as the "magic value" for undefined.
+// This is to avoid the need for an optional `lang` property on the protocol,
+// which would cause confusing issues when adopters provide a property of type `String`.
+private let defaultUndefinedLanguage = ""
 
-extension HTMLDocument.Language {
-    static let undefined = HTMLDocument.Language()
+public extension HTMLDocument {
+    /// The default value for the `lang` property is an empty string and will not be rendered in the HTML.
+    var lang: String { defaultUndefinedLanguage }
 }

--- a/Tests/ElementaryTests/CompositionRenderingTest.swift
+++ b/Tests/ElementaryTests/CompositionRenderingTest.swift
@@ -5,7 +5,7 @@ final class CompositionRenderingTests: XCTestCase {
     func testRendersADocument() async throws {
         try await HTMLAssertEqual(
             MyPage(text: "my text"),
-            #"<!DOCTYPE html><html><head><title>Foo</title><meta name="author" content="Me"><meta name="description" content="Test page"></head><body><div><h1>Hello, world!</h1><p>my text</p></div></body></html>"#
+            #"<!DOCTYPE html><html lang="en"><head><title>Foo</title><meta name="author" content="Me"><meta name="description" content="Test page"></head><body><div><h1>Hello, world!</h1><p>my text</p></div></body></html>"#
         )
     }
 
@@ -39,6 +39,7 @@ struct MyPage: HTMLDocument {
     var text: String
 
     var title: String = "Foo"
+    var lang: String = "en"
 
     var head: some HTML {
         meta(.name(.author), .content("Me"))

--- a/Tests/ElementaryTests/CompositionRenderingTest.swift
+++ b/Tests/ElementaryTests/CompositionRenderingTest.swift
@@ -38,8 +38,8 @@ final class CompositionRenderingTests: XCTestCase {
 struct MyPage: HTMLDocument {
     var text: String
 
-    var title: String = "Foo"
-    var lang: String = "en"
+    var title = "Foo"
+    var lang = "en"
 
     var head: some HTML {
         meta(.name(.author), .content("Me"))


### PR DESCRIPTION
The [`lang`](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/lang) global attribute allows declaring the language of a HTML element. The W3C [recommends](https://www.w3.org/International/questions/qa-html-language-declarations.en.html) to declare it on the document's `<html>` element rather than the `<body>` to also cover the text in the head (e.g. the title).

This PR adds the ability to specify the `lang` attribute for the `html` element in a `HTMLDocument`.