### PR TITLE
add 'placeholder' and 'accept' attributes to input tag

### DIFF
--- a/Sources/Elementary/HtmlAttributes.swift
+++ b/Sources/Elementary/HtmlAttributes.swift
@@ -551,6 +551,18 @@ public extension HTMLAttribute where Tag == HTMLTag.input {
         public static var week: Self { .init(value: "week") }
     }
 
+    struct Accept: Sendable, Equatable, ExpressibleByStringLiteral {
+        var value: String
+
+        init(value: String) {
+            self.value = value
+        }
+
+        public init(stringLiteral value: StringLiteralType) {
+            self.value = value
+        }
+    }
+
     static func type(_ type: InputType) -> Self {
         HTMLAttribute(name: "type", value: type.value)
     }
@@ -561,6 +573,10 @@ public extension HTMLAttribute where Tag == HTMLTag.input {
 
     static var checked: Self {
         HTMLAttribute(name: "checked", value: nil)
+    }
+
+    static func accept(_ type: Accept) -> Self {
+        HTMLAttribute(name: "accept", value: type.value)
     }
 }
 

--- a/Sources/Elementary/HtmlAttributes.swift
+++ b/Sources/Elementary/HtmlAttributes.swift
@@ -620,3 +620,17 @@ public extension HTMLAttribute where Tag == HTMLTag.script {
         HTMLAttribute(name: "nomodule", value: nil)
     }
 }
+
+// placeholder attribute
+public extension HTMLTrait.Attributes {
+    protocol placeholder {}
+}
+
+extension HTMLTag.input: HTMLTrait.Attributes.placeholder {}
+extension HTMLTag.textarea: HTMLTrait.Attributes.placeholder {}
+
+public extension HTMLAttribute where Tag: HTMLTrait.Attributes.placeholder {
+    static func placeholder(_ value: String) -> Self {
+        HTMLAttribute(name: "placeholder", value: value)
+    }
+}


### PR DESCRIPTION
I thought about adding some mime types to the `accept` attribute, but there are so many possibilities that I just left it as an `ExpressibleByStringLiteral`. I didn't left it as String in case someone wants to add some static values in their projects, for example, in my project I will probably add `static let imagePng` and `static let imageJpg`.

Let me know if you rather do it differently.

https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/accept

Also, sorry for so many PRs, I'm just adding stuff as I'm needing