### PR TITLE
expose `_RenderingContext.emptyContext`

### DIFF
--- a/Sources/Elementary/Core/CoreModel.swift
+++ b/Sources/Elementary/Core/CoreModel.swift
@@ -50,7 +50,7 @@ extension Never: HTMLTagDefinition {
 public struct _RenderingContext {
     var attributes: AttributeStorage
 
-    static var emptyContext: Self { Self(attributes: .none) }
+    public static var emptyContext: Self { Self(attributes: .none) }
 }
 
 // TODO: think about this interface... seems not ideal


### PR DESCRIPTION
This change makes the `static var emptyContext` public, so I can use it in my custom renderer.

That's necessary because when creating a custom renderer, It's impossible to run `HTML._render` since one of its arguments is a `_RenderingContext` and it doesn't expose initializers.