### PR TITLE
Add several useful global attributes

### DIFF
--- a/Sources/Elementary/HtmlAttributes.swift
+++ b/Sources/Elementary/HtmlAttributes.swift
@@ -59,10 +59,6 @@ public extension HTMLAttribute where Tag: HTMLTrait.Attributes.Global {
         HTMLAttribute(name: "draggable", value: value.value)
     }
 
-    static func anchor(_ value: String) -> Self {
-        HTMLAttribute(name: "anchor", value: value)
-    }
-
     static func `is`(_ value: String) -> Self {
         HTMLAttribute(name: "is", value: value)
     }

--- a/Sources/Elementary/HtmlAttributes.swift
+++ b/Sources/Elementary/HtmlAttributes.swift
@@ -39,12 +39,16 @@ public extension HTMLAttribute where Tag: HTMLTrait.Attributes.Global {
         HTMLAttribute(name: "tabindex", value: "\(index)")
     }
 
-    static func role(_ role: String) -> Self {
-        HTMLAttribute(name: "role", value: role)
+    static func role(_ role: HTMLAttributeValue.Role) -> Self {
+        HTMLAttribute(name: "role", value: role.rawValue)
     }
 
-    static func popover(_ popover: String) -> Self {
-        HTMLAttribute(name: "popover", value: popover)
+    static var popover: Self {
+        HTMLAttribute(name: "popover", value: "auto")
+    }
+
+    static func popover(_ popover: HTMLAttributeValue.Popover) -> Self {
+        HTMLAttribute(name: "popover", value: popover.value)
     }
 
     static var inert: Self {
@@ -95,19 +99,64 @@ public extension HTMLAttributeValue {
 }
 
 public extension HTMLAttributeValue {
+    struct Popover {
+        var value: String
+
+        public static var auto: Self { .init(value: "auto") }
+        public static var hint: Self { .init(value: "hint") }
+        public static var manual: Self { .init(value: "manual") }
+    }
+}
+
+public extension HTMLAttributeValue {
     // MDN docs describe draggable as having an enumerated value, but currently
     // the only valid values are "true" and "false"
     struct Draggable {
         var value: String
 
-        public static var true_: Self { .init(value: "true") }
-        public static var false_: Self { .init(value: "false") }
+        public static var `true`: Self { .init(value: "true") }
+        public static var `false`: Self { .init(value: "false") }
     }
 }
 
 public extension HTMLAttribute where Tag: HTMLTrait.Attributes.Global {
     static func dir(_ value: HTMLAttributeValue.Direction) -> Self {
         HTMLAttribute(name: "dir", value: value.value)
+    }
+}
+
+public extension HTMLAttributeValue {
+    struct Role: ExpressibleByStringLiteral, RawRepresentable {
+        public var rawValue: String
+
+        public init(rawValue: String) {
+            self.rawValue = rawValue
+        }
+
+        public init(stringLiteral value: String) {
+            rawValue = value
+        }
+
+        public static var banner: Self { "banner" }
+        public static var main: Self { "banner" }
+        public static var navigation: Self { "banner" }
+        public static var contentinfo: Self { "banner" }
+        public static var complementary: Self { "banner" }
+        public static var form: Self { "banner" }
+        public static var search: Self { "banner" }
+
+        public static var button: Self { "banner" }
+        public static var checkbox: Self { "banner" }
+        public static var link: Self { "banner" }
+        public static var menuitem: Self { "banner" }
+        public static var option: Self { "banner" }
+
+        public static var article: Self { "banner" }
+        public static var table: Self { "banner" }
+        public static var heading: Self { "banner" }
+        public static var list: Self { "banner" }
+        public static var listitem: Self { "banner" }
+        public static var figure: Self { "banner" }
     }
 }
 
@@ -266,22 +315,6 @@ public extension HTMLAttributeValue {
 public extension HTMLAttribute where Tag: HTMLTrait.Attributes.target {
     static func target(_ target: HTMLAttributeValue.Target) -> Self {
         HTMLAttribute(name: "target", value: target.rawValue)
-    }
-}
-
-// autofocus attribute
-public extension HTMLTrait.Attributes {
-    protocol autofocus {}
-}
-
-extension HTMLTag.button: HTMLTrait.Attributes.autofocus {}
-extension HTMLTag.input: HTMLTrait.Attributes.autofocus {}
-extension HTMLTag.select: HTMLTrait.Attributes.autofocus {}
-extension HTMLTag.textarea: HTMLTrait.Attributes.autofocus {}
-
-public extension HTMLAttribute where Tag: HTMLTrait.Attributes.autofocus {
-    static var autofocus: Self {
-        HTMLAttribute(name: "autofocus", value: nil)
     }
 }
 

--- a/Sources/Elementary/HtmlAttributes.swift
+++ b/Sources/Elementary/HtmlAttributes.swift
@@ -125,6 +125,7 @@ public extension HTMLAttribute where Tag: HTMLTrait.Attributes.Global {
     }
 }
 
+// role attribute
 public extension HTMLAttributeValue {
     struct Role: ExpressibleByStringLiteral, RawRepresentable {
         public var rawValue: String
@@ -136,27 +137,6 @@ public extension HTMLAttributeValue {
         public init(stringLiteral value: String) {
             rawValue = value
         }
-
-        public static var banner: Self { "banner" }
-        public static var main: Self { "main" }
-        public static var navigation: Self { "navigation" }
-        public static var contentinfo: Self { "contentinfo" }
-        public static var complementary: Self { "complementary" }
-        public static var form: Self { "form" }
-        public static var search: Self { "search" }
-
-        public static var button: Self { "button" }
-        public static var checkbox: Self { "checkbox" }
-        public static var link: Self { "link" }
-        public static var menuitem: Self { "menuitem" }
-        public static var option: Self { "option" }
-
-        public static var article: Self { "article" }
-        public static var table: Self { "table" }
-        public static var heading: Self { "heading" }
-        public static var list: Self { "list" }
-        public static var listitem: Self { "listitem" }
-        public static var figure: Self { "figure" }
     }
 }
 

--- a/Sources/Elementary/HtmlAttributes.swift
+++ b/Sources/Elementary/HtmlAttributes.swift
@@ -44,7 +44,7 @@ public extension HTMLAttribute where Tag: HTMLTrait.Attributes.Global {
     }
 
     static var popover: Self {
-        HTMLAttribute(name: "popover", value: "auto")
+        HTMLAttribute(name: "popover", value: nil)
     }
 
     static func popover(_ popover: HTMLAttributeValue.Popover) -> Self {

--- a/Sources/Elementary/HtmlAttributes.swift
+++ b/Sources/Elementary/HtmlAttributes.swift
@@ -138,25 +138,25 @@ public extension HTMLAttributeValue {
         }
 
         public static var banner: Self { "banner" }
-        public static var main: Self { "banner" }
-        public static var navigation: Self { "banner" }
-        public static var contentinfo: Self { "banner" }
-        public static var complementary: Self { "banner" }
-        public static var form: Self { "banner" }
-        public static var search: Self { "banner" }
+        public static var main: Self { "main" }
+        public static var navigation: Self { "navigation" }
+        public static var contentinfo: Self { "contentinfo" }
+        public static var complementary: Self { "complementary" }
+        public static var form: Self { "form" }
+        public static var search: Self { "search" }
 
-        public static var button: Self { "banner" }
-        public static var checkbox: Self { "banner" }
-        public static var link: Self { "banner" }
-        public static var menuitem: Self { "banner" }
-        public static var option: Self { "banner" }
+        public static var button: Self { "button" }
+        public static var checkbox: Self { "checkbox" }
+        public static var link: Self { "link" }
+        public static var menuitem: Self { "menuitem" }
+        public static var option: Self { "option" }
 
-        public static var article: Self { "banner" }
-        public static var table: Self { "banner" }
-        public static var heading: Self { "banner" }
-        public static var list: Self { "banner" }
-        public static var listitem: Self { "banner" }
-        public static var figure: Self { "banner" }
+        public static var article: Self { "article" }
+        public static var table: Self { "table" }
+        public static var heading: Self { "heading" }
+        public static var list: Self { "list" }
+        public static var listitem: Self { "listitem" }
+        public static var figure: Self { "figure" }
     }
 }
 

--- a/Sources/Elementary/HtmlAttributes.swift
+++ b/Sources/Elementary/HtmlAttributes.swift
@@ -38,6 +38,43 @@ public extension HTMLAttribute where Tag: HTMLTrait.Attributes.Global {
     static func tabindex(_ index: Int) -> Self {
         HTMLAttribute(name: "tabindex", value: "\(index)")
     }
+
+    static func role(_ role: String) -> Self {
+        HTMLAttribute(name: "role", value: role)
+    }
+
+    static func popover(_ popover: String) -> Self {
+        HTMLAttribute(name: "popover", value: popover)
+    }
+
+    static var inert: Self {
+        HTMLAttribute(name: "inert", value: nil)
+    }
+
+    static func contenteditable(_ value: HTMLAttributeValue.ContentEditable) -> Self {
+        HTMLAttribute(name: "contenteditable", value: value.value)
+    }
+
+    static func draggable(_ value: HTMLAttributeValue.Draggable) -> Self {
+        HTMLAttribute(name: "draggable", value: value.value)
+    }
+
+    static func anchor(_ value: String) -> Self {
+        HTMLAttribute(name: "anchor", value: value)
+    }
+
+    static func `is`(_ value: String) -> Self {
+        HTMLAttribute(name: "is", value: value)
+    }
+
+    static func slot(_ value: String) -> Self {
+        HTMLAttribute(name: "slot", value: value)
+    }
+
+    static var autofocus: Self {
+        HTMLAttribute(name: "autofocus", value: nil)
+    }
+
 }
 
 // dir attribute
@@ -48,6 +85,27 @@ public extension HTMLAttributeValue {
         public static var ltr: Self { .init(value: "ltr") }
         public static var rtl: Self { .init(value: "rtl") }
         public static var auto: Self { .init(value: "auto") }
+    }
+}
+
+public extension HTMLAttributeValue {
+    struct ContentEditable {
+        var value: String
+
+        public static var `true`: Self { .init(value: "true") }
+        public static var `false`: Self { .init(value: "false") }
+        public static var plaintextOnly: Self { .init(value: "plaintext-only") }
+    }
+}
+
+public extension HTMLAttributeValue {
+    // MDN docs describe draggable as having an enumerated value, but currently
+    // the only valid values are "true" and "false"
+    struct Draggable {
+        var value: String
+
+        public static var true_: Self { .init(value: "true") }
+        public static var false_: Self { .init(value: "false") }
     }
 }
 


### PR DESCRIPTION
This PR adds support for the following global attributes:

- [role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles)
- [popover](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/popover)
- [inert](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inert)
- [contenteditable](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/contenteditable)
- [draggable](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/draggable)
- [is](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/is)
- [slot](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/slot)
- [autofocus](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/autofocus)

These attributes are useful in practice for accessibility, web components, and rich application UI, and I believe they warrant including in Elementary.