### PR TITLE
fix(embedded): restore synchronous rendering under Embedded Swift

### DIFF
--- a/Sources/Elementary/Content/Content+Renderable.swift
+++ b/Sources/Elementary/Content/Content+Renderable.swift
@@ -1,4 +1,3 @@
-#if !hasFeature(Embedded)
 extension Optional: _Renderable where Wrapped: _Renderable {
     @inlinable
     public static func _render<Renderer: _HTMLRendering>(
@@ -12,6 +11,7 @@ extension Optional: _Renderable where Wrapped: _Renderable {
         }
     }
 
+    #if !hasFeature(Embedded)
     @inlinable
     @_unavailableInEmbedded
     public static func _render<Renderer: _AsyncHTMLRendering>(
@@ -24,6 +24,7 @@ extension Optional: _Renderable where Wrapped: _Renderable {
         case let .some(value): try await Wrapped._render(value, into: &renderer, with: context)
         }
     }
+    #endif
 }
 
 extension EmptyContent: _Renderable {
@@ -36,6 +37,7 @@ extension EmptyContent: _Renderable {
         context.assertNoAttributes(self)
     }
 
+    #if !hasFeature(Embedded)
     @inlinable
     @_unavailableInEmbedded
     public static func _render<Renderer: _AsyncHTMLRendering>(
@@ -45,6 +47,7 @@ extension EmptyContent: _Renderable {
     ) async throws {
         context.assertNoAttributes(self)
     }
+    #endif
 }
 
 extension StringContent: _Renderable {
@@ -58,6 +61,7 @@ extension StringContent: _Renderable {
         renderer.appendToken(.text(html.text))
     }
 
+    #if !hasFeature(Embedded)
     @inlinable
     @_unavailableInEmbedded
     public static func _render<Renderer: _AsyncHTMLRendering>(
@@ -68,6 +72,7 @@ extension StringContent: _Renderable {
         context.assertNoAttributes(self)
         try await renderer.appendToken(.text(html.text))
     }
+    #endif
 }
 
 extension Group: _Renderable where Content: _Renderable {
@@ -81,6 +86,7 @@ extension Group: _Renderable where Content: _Renderable {
         Content._render(html.content, into: &renderer, with: context)
     }
 
+    #if !hasFeature(Embedded)
     @inlinable
     @_unavailableInEmbedded
     public static func _render<Renderer: _AsyncHTMLRendering>(
@@ -91,6 +97,7 @@ extension Group: _Renderable where Content: _Renderable {
         context.assertNoAttributes(self)
         try await Content._render(html.content, into: &renderer, with: context)
     }
+    #endif
 }
 
 extension ForEach: _Renderable where Content: _Renderable {
@@ -107,6 +114,7 @@ extension ForEach: _Renderable where Content: _Renderable {
         }
     }
 
+    #if !hasFeature(Embedded)
     @inlinable
     @_unavailableInEmbedded
     public static func _render<Renderer: _AsyncHTMLRendering>(
@@ -120,6 +128,7 @@ extension ForEach: _Renderable where Content: _Renderable {
             try await Content._render(html._contentBuilder(element), into: &renderer, with: copy context)
         }
     }
+    #endif
 }
 
 extension _ConditionalContent: _Renderable where TrueContent: _Renderable, FalseContent: _Renderable {
@@ -135,6 +144,7 @@ extension _ConditionalContent: _Renderable where TrueContent: _Renderable, False
         }
     }
 
+    #if !hasFeature(Embedded)
     @inlinable
     @_unavailableInEmbedded
     public static func _render<Renderer: _AsyncHTMLRendering>(
@@ -147,6 +157,7 @@ extension _ConditionalContent: _Renderable where TrueContent: _Renderable, False
         case let .falseContent(content): try await FalseContent._render(content, into: &renderer, with: context)
         }
     }
+    #endif
 }
 
 extension _ArrayContent: _Renderable where Element: _Renderable {
@@ -163,6 +174,7 @@ extension _ArrayContent: _Renderable where Element: _Renderable {
         }
     }
 
+    #if !hasFeature(Embedded)
     @inlinable
     @_unavailableInEmbedded
     public static func _render<Renderer: _AsyncHTMLRendering>(
@@ -176,6 +188,7 @@ extension _ArrayContent: _Renderable where Element: _Renderable {
             try await Element._render(element, into: &renderer, with: copy context)
         }
     }
+    #endif
 }
 
 extension _TupleContent2: _Renderable where V0: _Renderable, V1: _Renderable {
@@ -191,6 +204,7 @@ extension _TupleContent2: _Renderable where V0: _Renderable, V1: _Renderable {
         V1._render(html.v1, into: &renderer, with: copy context)
     }
 
+    #if !hasFeature(Embedded)
     @inlinable
     @_unavailableInEmbedded
     public static func _render<Renderer: _AsyncHTMLRendering>(
@@ -203,6 +217,7 @@ extension _TupleContent2: _Renderable where V0: _Renderable, V1: _Renderable {
         try await V0._render(html.v0, into: &renderer, with: copy context)
         try await V1._render(html.v1, into: &renderer, with: copy context)
     }
+    #endif
 }
 
 extension _TupleContent3: _Renderable where V0: _Renderable, V1: _Renderable, V2: _Renderable {
@@ -219,6 +234,7 @@ extension _TupleContent3: _Renderable where V0: _Renderable, V1: _Renderable, V2
         V2._render(html.v2, into: &renderer, with: copy context)
     }
 
+    #if !hasFeature(Embedded)
     @inlinable
     @_unavailableInEmbedded
     public static func _render<Renderer: _AsyncHTMLRendering>(
@@ -232,6 +248,7 @@ extension _TupleContent3: _Renderable where V0: _Renderable, V1: _Renderable, V2
         try await V1._render(html.v1, into: &renderer, with: copy context)
         try await V2._render(html.v2, into: &renderer, with: copy context)
     }
+    #endif
 }
 
 extension _TupleContent4: _Renderable where V0: _Renderable, V1: _Renderable, V2: _Renderable, V3: _Renderable {
@@ -249,6 +266,7 @@ extension _TupleContent4: _Renderable where V0: _Renderable, V1: _Renderable, V2
         V3._render(html.v3, into: &renderer, with: copy context)
     }
 
+    #if !hasFeature(Embedded)
     @inlinable
     @_unavailableInEmbedded
     public static func _render<Renderer: _AsyncHTMLRendering>(
@@ -263,6 +281,7 @@ extension _TupleContent4: _Renderable where V0: _Renderable, V1: _Renderable, V2
         try await V2._render(html.v2, into: &renderer, with: copy context)
         try await V3._render(html.v3, into: &renderer, with: copy context)
     }
+    #endif
 }
 
 extension _TupleContent5: _Renderable where V0: _Renderable, V1: _Renderable, V2: _Renderable, V3: _Renderable, V4: _Renderable {
@@ -281,6 +300,7 @@ extension _TupleContent5: _Renderable where V0: _Renderable, V1: _Renderable, V2
         V4._render(html.v4, into: &renderer, with: copy context)
     }
 
+    #if !hasFeature(Embedded)
     @inlinable
     @_unavailableInEmbedded
     public static func _render<Renderer: _AsyncHTMLRendering>(
@@ -296,6 +316,7 @@ extension _TupleContent5: _Renderable where V0: _Renderable, V1: _Renderable, V2
         try await V3._render(html.v3, into: &renderer, with: copy context)
         try await V4._render(html.v4, into: &renderer, with: copy context)
     }
+    #endif
 }
 
 extension _TupleContent6: _Renderable
@@ -316,6 +337,7 @@ where V0: _Renderable, V1: _Renderable, V2: _Renderable, V3: _Renderable, V4: _R
         V5._render(html.v5, into: &renderer, with: copy context)
     }
 
+    #if !hasFeature(Embedded)
     @inlinable
     @_unavailableInEmbedded
     public static func _render<Renderer: _AsyncHTMLRendering>(
@@ -332,6 +354,7 @@ where V0: _Renderable, V1: _Renderable, V2: _Renderable, V3: _Renderable, V4: _R
         try await V4._render(html.v4, into: &renderer, with: copy context)
         try await V5._render(html.v5, into: &renderer, with: copy context)
     }
+    #endif
 }
 
 #if !hasFeature(Embedded)
@@ -438,5 +461,4 @@ extension _TupleContent: _Renderable where repeat each Child: _Renderable {
         repeat try await renderElement(each html.value, &renderer)
     }
 }
-#endif
 #endif

--- a/Sources/Elementary/HTML/HTML+Renderable.swift
+++ b/Sources/Elementary/HTML/HTML+Renderable.swift
@@ -1,4 +1,3 @@
-#if !hasFeature(Embedded)
 extension HTMLTagDefinition {
     @inlinable
     static var renderingType: _HTMLRenderToken.RenderingType {
@@ -20,6 +19,7 @@ extension HTMLElement {
         renderer.appendToken(.endTag(Tag.name, type: Tag.renderingType))
     }
 
+    #if !hasFeature(Embedded)
     @inlinable
     @_unavailableInEmbedded
     public static func _render<Renderer: _AsyncHTMLRendering>(
@@ -35,6 +35,7 @@ extension HTMLElement {
         try await Content._render(html.content, into: &renderer, with: .emptyContext)
         try await renderer.appendToken(.endTag(Tag.name, type: Tag.renderingType))
     }
+    #endif
 }
 
 extension HTMLVoidElement {
@@ -48,6 +49,7 @@ extension HTMLVoidElement {
         renderer.appendToken(.startTag(Tag.name, attributes: html._attributes.flattened(), isUnpaired: true, type: Tag.renderingType))
     }
 
+    #if !hasFeature(Embedded)
     @inlinable
     @_unavailableInEmbedded
     public static func _render<Renderer: _AsyncHTMLRendering>(
@@ -60,6 +62,7 @@ extension HTMLVoidElement {
             .startTag(Tag.name, attributes: html._attributes.flattened(), isUnpaired: true, type: Tag.renderingType)
         )
     }
+    #endif
 }
 
 extension HTMLComment {
@@ -73,6 +76,7 @@ extension HTMLComment {
         renderer.appendToken(.comment(html.text))
     }
 
+    #if !hasFeature(Embedded)
     @inlinable
     @_unavailableInEmbedded
     public static func _render<Renderer: _AsyncHTMLRendering>(
@@ -83,6 +87,7 @@ extension HTMLComment {
         context.assertNoAttributes(self)
         try await renderer.appendToken(.comment(html.text))
     }
+    #endif
 }
 
 extension HTMLRaw {
@@ -96,6 +101,7 @@ extension HTMLRaw {
         renderer.appendToken(.raw(html.text))
     }
 
+    #if !hasFeature(Embedded)
     @inlinable
     @_unavailableInEmbedded
     public static func _render<Renderer: _AsyncHTMLRendering>(
@@ -106,6 +112,6 @@ extension HTMLRaw {
         context.assertNoAttributes(self)
         try await renderer.appendToken(.raw(html.text))
     }
+    #endif
 }
 
-#endif

--- a/Sources/Elementary/HTML/HTMLDocument.swift
+++ b/Sources/Elementary/HTML/HTMLDocument.swift
@@ -59,7 +59,6 @@ public extension HTMLDocument {
     var bodyAttributes: [HTMLAttribute<HTMLTag.body>] { [] }
 }
 
-#if !hasFeature(Embedded)
 // NOTE: this is a bit messy after the renaming of var content to var body
 public extension HTMLDocument {
     static func _render<Renderer: _HTMLRendering>(
@@ -74,6 +73,7 @@ public extension HTMLDocument {
         render(html.__body, into: &renderer, with: context)
     }
 
+    #if !hasFeature(Embedded)
     @_unavailableInEmbedded
     static func _render<Renderer: _AsyncHTMLRendering>(
         _ html: consuming Self,
@@ -90,6 +90,7 @@ public extension HTMLDocument {
 
         try await render(html.__body, into: &renderer, with: context)
     }
+    #endif
 
     @ContentBuilder var __body: some HTML {
         HTMLRaw("<!DOCTYPE html>")
@@ -104,4 +105,3 @@ public extension HTMLDocument {
         .attributes(.dir(dir), when: dir.value != defaultUndefinedDirection)
     }
 }
-#endif

--- a/Sources/Elementary/Markup/Markup+Renderable.swift
+++ b/Sources/Elementary/Markup/Markup+Renderable.swift
@@ -1,4 +1,3 @@
-#if !hasFeature(Embedded)
 public extension MarkupContent {
     @inlinable
     static func _render<Renderer: _HTMLRendering>(
@@ -9,6 +8,7 @@ public extension MarkupContent {
         Body._render(html.body, into: &renderer, with: context)
     }
 
+    #if !hasFeature(Embedded)
     @inlinable
     @_unavailableInEmbedded
     static func _render<Renderer: _AsyncHTMLRendering>(
@@ -18,6 +18,7 @@ public extension MarkupContent {
     ) async throws {
         try await Body._render(html.body, into: &renderer, with: context)
     }
+    #endif
 }
 
 extension _AttributedContent: _Renderable where Content: _Renderable {
@@ -31,6 +32,7 @@ extension _AttributedContent: _Renderable where Content: _Renderable {
         Content._render(html.content, into: &renderer, with: context)
     }
 
+    #if !hasFeature(Embedded)
     @inlinable
     @_unavailableInEmbedded
     public static func _render<Renderer: _AsyncHTMLRendering>(
@@ -41,6 +43,7 @@ extension _AttributedContent: _Renderable where Content: _Renderable {
         context.prependAttributes(html._attributes)
         try await Content._render(html.content, into: &renderer, with: context)
     }
+    #endif
 }
 
 extension _RenderingContext {
@@ -50,4 +53,3 @@ extension _RenderingContext {
         self.attributes = attributes
     }
 }
-#endif

--- a/Sources/Elementary/Rendering/HtmlTextRenderer.swift
+++ b/Sources/Elementary/Rendering/HtmlTextRenderer.swift
@@ -2,7 +2,6 @@
 import Foundation
 #endif
 
-#if !hasFeature(Embedded)
 struct HTMLTextRenderer: _HTMLRendering {
     private var result: [UInt8] = []
 
@@ -20,6 +19,7 @@ struct HTMLTextRenderer: _HTMLRendering {
     }
 }
 
+#if !hasFeature(Embedded)
 struct PrettyHTMLTextRenderer {
     let indentation: String
 

--- a/Sources/Elementary/Rendering/MarkupContent+Render.swift
+++ b/Sources/Elementary/Rendering/MarkupContent+Render.swift
@@ -1,4 +1,3 @@
-#if !hasFeature(Embedded)
 public extension MarkupContent {
     /// Renders the HTML content into a single string.
     /// - Returns: The rendered HTML content.
@@ -10,7 +9,10 @@ public extension MarkupContent {
         Self._render(self, into: &renderer, with: .emptyContext)
         return renderer.collect()
     }
+}
 
+#if !hasFeature(Embedded)
+public extension MarkupContent {
     /// Renders the HTML content into a formatted string.
     /// - Returns: The rendered HTML content.
     ///

--- a/Sources/Elementary/Rendering/Renderable.swift
+++ b/Sources/Elementary/Rendering/Renderable.swift
@@ -1,4 +1,3 @@
-#if !hasFeature(Embedded)
 /// A type that represents markup content that can be rendered.
 ///
 /// This protocol contains the namespace-neutral rendering machinery shared by HTML and SVG.
@@ -9,12 +8,14 @@ public protocol _Renderable {
         with context: consuming _RenderingContext
     )
 
+    #if !hasFeature(Embedded)
     @_unavailableInEmbedded
     static func _render<Renderer: _AsyncHTMLRendering>(
         _ html: consuming Self,
         into renderer: inout Renderer,
         with context: consuming _RenderingContext
     ) async throws
+    #endif
 }
 
 public struct _RenderingContext {
@@ -43,10 +44,8 @@ public protocol _HTMLRendering {
     mutating func appendToken(_ token: consuming _HTMLRenderToken)
 }
 
+#if !hasFeature(Embedded)
 public protocol _AsyncHTMLRendering {
     mutating func appendToken(_ token: consuming _HTMLRenderToken) async throws
 }
-#else
-// empty protocol for embedded
-public typealias _Renderable = Any
 #endif

--- a/Sources/Elementary/Rendering/RenderingUtils.swift
+++ b/Sources/Elementary/Rendering/RenderingUtils.swift
@@ -1,4 +1,3 @@
-#if !hasFeature(Embedded)
 extension _RenderingContext {
     @inline(__always)
     @usableFromInline
@@ -139,4 +138,3 @@ extension [UInt8] {
         }
     }
 }
-#endif

--- a/Sources/Elementary/SVG/SVG+Renderable.swift
+++ b/Sources/Elementary/SVG/SVG+Renderable.swift
@@ -1,4 +1,3 @@
-#if !hasFeature(Embedded)
 extension SVGTagDefinition {
     @inlinable
     static var renderingType: _HTMLRenderToken.RenderingType {
@@ -26,6 +25,7 @@ extension SVGElement {
         renderer.appendToken(.endTag(Tag.name, type: Tag.renderingType))
     }
 
+    #if !hasFeature(Embedded)
     @inlinable
     @_unavailableInEmbedded
     public static func _render<Renderer: _AsyncHTMLRendering>(
@@ -45,5 +45,5 @@ extension SVGElement {
         try await Content._render(svg.content, into: &renderer, with: .emptyContext)
         try await renderer.appendToken(.endTag(Tag.name, type: Tag.renderingType))
     }
+    #endif
 }
-#endif


### PR DESCRIPTION
Adapted from d432ba9 (feature/svg) for main's single-target layout.

- the render layer was fully excluded in Embedded, not just the async path
- split sync from async: render() -> String, [UInt8].appendToken and HTMLTextRenderer are available in Embedded again (HTML + SVG)
- async streaming stays excluded — AsyncSequence/TaskLocal/Mutex are unavailable in Embedded
- SVG: keep the renderingType helper available in Embedded so the sync path resolves; only the async _render stays behind #if !hasFeature(Embedded)