### PR TITLE
formatted rendering: keep inline element text on its own line after a block sibling

### DIFF
--- a/Sources/Elementary/Rendering/HtmlTextRenderer.swift
+++ b/Sources/Elementary/Rendering/HtmlTextRenderer.swift
@@ -88,7 +88,7 @@ extension PrettyHTMLTextRenderer: _HTMLRendering {
 
         switch token {
         case .selfClosingTag(_, attributes: _):
-            flushInlineText(forceLineBreak: isInLineAfterBlockTagOpen)
+            flushInlineText(forceLineBreak: true)
             addLineBreak()
             result += renderedToken
         case let .startTag(_, attributes: _, isUnpaired: isUnpaired, type: type):
@@ -96,7 +96,7 @@ extension PrettyHTMLTextRenderer: _HTMLRendering {
             case .inline:
                 currentInlineText += renderedToken
             case .block:
-                flushInlineText(forceLineBreak: isInLineAfterBlockTagOpen)
+                flushInlineText(forceLineBreak: true)
                 addLineBreak()
                 result += renderedToken
 

--- a/Sources/Elementary/Rendering/HtmlTextRenderer.swift
+++ b/Sources/Elementary/Rendering/HtmlTextRenderer.swift
@@ -118,7 +118,7 @@ extension PrettyHTMLTextRenderer: _HTMLRendering {
                     let hasBroken = flushInlineText()
                     shouldLineBreak = hasBroken
                 } else {
-                    flushInlineText()
+                    flushInlineText(forceLineBreak: true)
                     shouldLineBreak = true
                 }
 
@@ -131,7 +131,7 @@ extension PrettyHTMLTextRenderer: _HTMLRendering {
                 result += renderedToken
             }
         case .text, .raw, .comment:
-            if isInLineAfterBlockTagOpen {
+            if isInLineAfterBlockTagOpen || !currentInlineText.isEmpty {
                 currentInlineText += renderedToken
             } else {
                 addLineBreak()

--- a/Tests/ElementaryTests/FormattedRenderingTest.swift
+++ b/Tests/ElementaryTests/FormattedRenderingTest.swift
@@ -173,6 +173,71 @@ struct FormatedRenderingTests {
         )
     }
 
+    @Test func testFormatsBlockSiblingAfterInlineAfterBlockSibling() {
+        HTMLFormattedAssertEqual(
+            div {
+                p { "a" }
+                span { "hi" }
+                p { "b" }
+            },
+            """
+            <div>
+              <p>a</p>
+              <span>hi</span>
+              <p>b</p>
+            </div>
+            """
+        )
+    }
+
+    @Test func testFormatsSelfClosingTagAfterInlineAfterBlockSibling() {
+        HTMLFormattedAssertEqual(
+            div {
+                p { "a" }
+                span { "hi" }
+                br()
+            },
+            """
+            <div>
+              <p>a</p>
+              <span>hi</span>
+              <br>
+            </div>
+            """
+        )
+    }
+
+    @Test func testFormatsConsecutiveInlineSiblingsAfterBlockSibling() {
+        HTMLFormattedAssertEqual(
+            div {
+                p { "a" }
+                span { "hi" }
+                span { "bye" }
+            },
+            """
+            <div>
+              <p>a</p>
+              <span>hi</span><span>bye</span>
+            </div>
+            """
+        )
+    }
+
+    @Test func testFormatsRawInsideInlineElementAfterBlockSibling() {
+        HTMLFormattedAssertEqual(
+            div {
+                p { "a" }
+                span { HTMLRaw("<b>raw</b>") }
+            },
+            """
+            <div>
+              <p>a</p>
+              <span><b>raw</b></span>
+            </div>
+            """
+        )
+    }
+
     @Test func testFormatsAttributes() {
         HTMLFormattedAssertEqual(
             div(.id("1")) {

--- a/Tests/ElementaryTests/FormattedRenderingTest.swift
+++ b/Tests/ElementaryTests/FormattedRenderingTest.swift
@@ -159,8 +159,6 @@ struct FormatedRenderingTests {
     }
 
     @Test func testFormatsInlineElementWithTextAfterBlockSibling() {
-        // An inline element (span) that contains text and follows a block sibling (p)
-        // inside a block parent. The text must stay inside the inline element.
         HTMLFormattedAssertEqual(
             div {
                 p { "a" }

--- a/Tests/ElementaryTests/FormattedRenderingTest.swift
+++ b/Tests/ElementaryTests/FormattedRenderingTest.swift
@@ -158,6 +158,23 @@ struct FormatedRenderingTests {
         )
     }
 
+    @Test func testFormatsInlineElementWithTextAfterBlockSibling() {
+        // An inline element (span) that contains text and follows a block sibling (p)
+        // inside a block parent. The text must stay inside the inline element.
+        HTMLFormattedAssertEqual(
+            div {
+                p { "a" }
+                span { "hi" }
+            },
+            """
+            <div>
+              <p>a</p>
+              <span>hi</span>
+            </div>
+            """
+        )
+    }
+
     @Test func testFormatsAttributes() {
         HTMLFormattedAssertEqual(
             div(.id("1")) {


### PR DESCRIPTION
Re-submits the rendering fix from #105.

`PrettyHTMLTextRenderer` buffers inline content and decides at three call sites whether to force a line break before flushing it. 